### PR TITLE
fix: use RPC instead of WebSocket to retrieve new blocks #NTRN-529

### DIFF
--- a/.env
+++ b/.env
@@ -26,6 +26,7 @@ SUBSCRIBE_NEW_BLOCKS=true # Subscribe to get new blocks by websocket
 PROCESS_ERROR_BLOCKS=true # Process error blocks again
 START_HEIGHT=13071519 # Start block height
 STOP_HEIGHT=0 # Stop block height
+PROCESS_NEW_BLOCKS_INTERVAL=1s # Interval to process new blocks
 PROCESS_ERROR_BLOCKS_INTERVAL=1m # Interval to reprocess error blocks again
 PROCESS_GENESIS=true # Parse 0 height of genesis
 MAX_MESSAGE_MAX_BYTES=5242880 # Max message size in bytes (5MB)

--- a/.env
+++ b/.env
@@ -22,8 +22,9 @@ BATCH_PRODUCER=false # Enable batch producer (increase performance but experimen
 
 # Worker settings
 WORKERS_COUNT=8 # Count of block processing processes
-SUBSCRIBE_NEW_BLOCKS=true # Subscribe to get new blocks by websocket
+PROCESS_NEW_BLOCKS=true # Process new blocks
 PROCESS_ERROR_BLOCKS=true # Process error blocks again
+REPROCESS_BLOCKS=false # Process blocks again
 START_HEIGHT=13071519 # Start block height
 STOP_HEIGHT=0 # Stop block height
 PROCESS_NEW_BLOCKS_INTERVAL=1s # Interval to process new blocks

--- a/adapter/storage/tx.go
+++ b/adapter/storage/tx.go
@@ -16,6 +16,15 @@ func (s *Storage) InsertErrorTx(ctx context.Context, tx model.Tx) error {
 	return nil
 }
 
+func (s *Storage) DeleteErrorTxs(ctx context.Context, height int64) error {
+	filter := bson.D{{Key: "height", Value: height}}
+	if _, err := s.txCollection.DeleteMany(ctx, filter); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (s *Storage) CountErrorTxs(ctx context.Context) (int64, error) {
 	return s.txCollection.CountDocuments(ctx, bson.D{})
 }

--- a/client/grpc/client.go
+++ b/client/grpc/client.go
@@ -9,15 +9,15 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
+	dex "github.com/neutron-org/neutron/v6/x/dex/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
+	oracle "github.com/skip-mev/slinky/x/oracle/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/bro-n-bro/spacebox-crawler/v2/adapter/storage/model"
-	dex "github.com/neutron-org/neutron/v6/x/dex/types"
-	oracle "github.com/skip-mev/slinky/x/oracle/types"
 )
 
 type (

--- a/client/grpc/tx.go
+++ b/client/grpc/tx.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"encoding/hex"
+	"strings"
 	"time"
 
 	cometbfttypes "github.com/cometbft/cometbft/types"
@@ -23,20 +24,24 @@ func (c *Client) Txs(ctx context.Context, height int64, txs cometbfttypes.Txs) (
 		if err != nil {
 			// treat common known error differently
 			if i == 0 && err.Error() == "rpc error: code = Unknown desc = codespace sdk code 2: "+
-				"tx parse error: expected 2 wire type, got 0" {
+				"tx parse error: expected 2 wire type, got 0" ||
+				strings.HasPrefix(err.Error(), "rpc error: code = NotFound desc = tx not found:") {
 				// just log this one quietly
 				c.log.Debug().Err(err).Int64("height", height).Msgf("GetTx error on txhash: %s", hash)
-			} else {
-				_ = c.storage.InsertErrorTx(ctx, model.Tx{
-					Created:      time.Now(),
-					ErrorMessage: err.Error(),
-					Hash:         hash,
-					Height:       height,
-				})
 
-				c.log.Warn().Err(err).Int64("height", height).Msgf("GetTx error on txhash: %s", hash)
+				continue
 			}
-			continue
+
+			_ = c.storage.InsertErrorTx(ctx, model.Tx{
+				Created:      time.Now(),
+				ErrorMessage: err.Error(),
+				Hash:         hash,
+				Height:       height,
+			})
+
+			c.log.Warn().Err(err).Int64("height", height).Msgf("GetTx error on txhash: %s", hash)
+
+			return nil, err
 		}
 
 		txResponses = append(txResponses, &tx.GetTxResponse{Tx: respPb.Tx, TxResponse: respPb.TxResponse})

--- a/client/grpc/tx.go
+++ b/client/grpc/tx.go
@@ -22,7 +22,8 @@ func (c *Client) Txs(ctx context.Context, height int64, txs cometbfttypes.Txs) (
 		respPb, err := c.TxService.GetTx(ctx, &tx.GetTxRequest{Hash: hash})
 		if err != nil {
 			// treat common known error differently
-			if i == 0 && err.Error() == `rpc error: code = Unknown desc = codespace sdk code 2: tx parse error: expected 2 wire type, got 0` {
+			if i == 0 && err.Error() == "rpc error: code = Unknown desc = codespace sdk code 2: "+
+				"tx parse error: expected 2 wire type, got 0" {
 				// just log this one quietly
 				c.log.Debug().Err(err).Int64("height", height).Msgf("GetTx error on txhash: %s", hash)
 			} else {

--- a/client/grpc/tx.go
+++ b/client/grpc/tx.go
@@ -3,7 +3,6 @@ package grpc
 import (
 	"context"
 	"encoding/hex"
-	"strings"
 	"time"
 
 	cometbfttypes "github.com/cometbft/cometbft/types"
@@ -24,8 +23,7 @@ func (c *Client) Txs(ctx context.Context, height int64, txs cometbfttypes.Txs) (
 		if err != nil {
 			// treat common known error differently
 			if i == 0 && err.Error() == "rpc error: code = Unknown desc = codespace sdk code 2: "+
-				"tx parse error: expected 2 wire type, got 0" ||
-				strings.HasPrefix(err.Error(), "rpc error: code = NotFound desc = tx not found:") {
+				"tx parse error: expected 2 wire type, got 0" {
 				// just log this one quietly
 				c.log.Debug().Err(err).Int64("height", height).Msgf("GetTx error on txhash: %s", hash)
 

--- a/delivery/broker/broker.go
+++ b/delivery/broker/broker.go
@@ -141,13 +141,10 @@ func (b *Broker) produce(topic Topic, data []byte) error {
 		return nil
 	}
 
-	deliveryChan := make(chan kafka.Event)
-	defer close(deliveryChan)
-
 	err := b.p.Produce(&kafka.Message{
 		TopicPartition: kafka.TopicPartition{Topic: topic, Partition: kafka.PartitionAny},
 		Value:          data,
-	}, deliveryChan)
+	}, nil)
 
 	if kafkaError, ok := err.(kafka.Error); ok && kafkaError.Code() == kafka.ErrQueueFull {
 		b.log.Info().Str("topic", *topic).Msg("kafka local queue full error. Going to Flush then retry")
@@ -160,14 +157,6 @@ func (b *Broker) produce(topic Topic, data []byte) error {
 
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("produce %s fail", *topic))
-	}
-
-	// Wait for delivery report
-	e := <-deliveryChan
-	m := e.(*kafka.Message)
-
-	if err := m.TopicPartition.Error; err != nil {
-		return errors.Wrap(err, fmt.Sprintf("delivery failed for %s", *topic))
 	}
 
 	return nil

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	neutronapp "github.com/neutron-org/neutron/v6/app"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -24,7 +25,6 @@ import (
 	healthchecker "github.com/bro-n-bro/spacebox-crawler/v2/pkg/health_checker"
 	ts "github.com/bro-n-bro/spacebox-crawler/v2/pkg/mapper/to_storage"
 	"github.com/bro-n-bro/spacebox-crawler/v2/pkg/worker"
-	neutronapp "github.com/neutron-org/neutron/v6/app"
 )
 
 const (

--- a/internal/rep/storage.go
+++ b/internal/rep/storage.go
@@ -16,6 +16,7 @@ type Storage interface {
 	GetErrorBlockHeights(ctx context.Context) ([]int64, error)
 
 	InsertErrorTx(ctx context.Context, message model.Tx) error
+	DeleteErrorTxs(ctx context.Context, height int64) error
 	InsertErrorMessage(ctx context.Context, message model.Message) error
 
 	Ping(ctx context.Context) error

--- a/modules/dex_pools/block.go
+++ b/modules/dex_pools/block.go
@@ -1,14 +1,15 @@
-package dex_pools
+package dexpools
 
 import (
 	"context"
 	"fmt"
 	"time"
 
-	"github.com/bro-n-bro/spacebox-crawler/v2/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	dex "github.com/neutron-org/neutron/v6/x/dex/types"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/bro-n-bro/spacebox-crawler/v2/types"
 )
 
 func (m *Module) HandleBlock(ctx context.Context, block *types.Block) error {
@@ -58,10 +59,15 @@ func (m *Module) publishDexPoolMetadata(ctx context.Context, height int64, times
 
 	// get multiple pages of data if needed
 	nextKey := heightResp.Pagination.NextKey
+
+	var nextPageHeightResp *dex.QueryAllPoolMetadataResponse
+
 	for {
 		if nextKey != nil {
-			nextPageHeightResp, err := m.grpcClient.DexService.PoolMetadataAll(
-				metadata.NewOutgoingContext(ctx, metadata.Pairs("x-cosmos-block-height", fmt.Sprintf("%d", height))),
+			nextPageHeightResp, err = m.grpcClient.DexService.PoolMetadataAll(
+				metadata.NewOutgoingContext(
+					ctx, metadata.Pairs("x-cosmos-block-height", fmt.Sprintf("%d", height)),
+				),
 				&dex.QueryAllPoolMetadataRequest{
 					Pagination: &query.PageRequest{
 						Offset:     previousHeightResp.Pagination.Total,
@@ -87,12 +93,12 @@ func (m *Module) publishDexPoolMetadata(ctx context.Context, height int64, times
 	}
 	rawDexPoolMetadata := struct {
 		Timestamp    time.Time          `json:"timestamp"`
-		Height       int64              `json:"height"`
 		PoolMetadata []dex.PoolMetadata `json:"pool_metadata"`
+		Height       int64              `json:"height"`
 	}{
 		Timestamp:    timestamp,
-		Height:       height,
 		PoolMetadata: poolMetadata,
+		Height:       height,
 	}
 	err = m.broker.PublishRawDexPoolMetadata(ctx, rawDexPoolMetadata)
 	if err != nil {

--- a/modules/dex_pools/module.go
+++ b/modules/dex_pools/module.go
@@ -1,4 +1,4 @@
-package dex_pools
+package dexpools
 
 import (
 	"context"
@@ -20,21 +20,23 @@ var (
 	_ types.BlockHandler = &Module{}
 )
 
-type Config struct {
-	StartDexHeight int64
-}
+type (
+	broker interface {
+		PublishRawDexPoolMetadata(ctx context.Context, data interface{}) error
+	}
 
-type Module struct {
-	log        *zerolog.Logger
-	rpcClient  *rpcClient.Client
-	grpcClient *grpcClient.Client
-	broker     broker
-	cfg        Config
-}
+	Config struct {
+		StartDexHeight int64
+	}
 
-type broker interface {
-	PublishRawDexPoolMetadata(ctx context.Context, data interface{}) error
-}
+	Module struct {
+		log        *zerolog.Logger
+		rpcClient  *rpcClient.Client
+		grpcClient *grpcClient.Client
+		broker     broker
+		cfg        Config
+	}
+)
 
 func New(cfg Config, b broker, rpcCli *rpcClient.Client, grpcCli *grpcClient.Client) *Module {
 	return &Module{

--- a/modules/raw/broker.go
+++ b/modules/raw/broker.go
@@ -7,6 +7,6 @@ type broker interface {
 	PublishRawTransaction(ctx context.Context, tx interface{}) error
 	PublishRawBlockResults(ctx context.Context, br interface{}) error
 	PublishRawSlinkyPrices(ctx context.Context, prices interface{}) error
-	PublishRawDexPoolMetadata(ctx context.Context, pool_metadata interface{}) error
+	PublishRawDexPoolMetadata(ctx context.Context, poolMetadata interface{}) error
 	PublishRawGenesis(ctx context.Context, g interface{}) error
 }

--- a/modules/slinky_prices/block.go
+++ b/modules/slinky_prices/block.go
@@ -1,12 +1,13 @@
-package slinky_prices
+package slinkyprices
 
 import (
 	"context"
 	"fmt"
 
-	"github.com/bro-n-bro/spacebox-crawler/v2/types"
 	oracle "github.com/skip-mev/slinky/x/oracle/types"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/bro-n-bro/spacebox-crawler/v2/types"
 )
 
 func (m *Module) HandleBlock(ctx context.Context, block *types.Block) error {
@@ -24,7 +25,9 @@ func (m *Module) publishBlockPrices(ctx context.Context, height int64) error {
 	header := metadata.Pairs("x-cosmos-block-height", fmt.Sprintf("%d", height))
 	ctxWithHeader := metadata.NewOutgoingContext(ctx, header)
 
-	pairsResp, err := m.grpcClient.OracleService.GetCurrencyPairMappingList(ctxWithHeader, &oracle.GetCurrencyPairMappingListRequest{})
+	pairsResp, err := m.grpcClient.OracleService.GetCurrencyPairMappingList(
+		ctxWithHeader, &oracle.GetCurrencyPairMappingListRequest{},
+	)
 	if err != nil {
 		return fmt.Errorf("failed to get currency pair mappings: %w", err)
 	}
@@ -46,13 +49,13 @@ func (m *Module) publishBlockPrices(ctx context.Context, height int64) error {
 
 	// Combine data and publish
 	rawPrices := struct {
-		Height   int64                        `json:"height"`
 		Mappings []oracle.CurrencyPairMapping `json:"mappings"`
 		Prices   []oracle.GetPriceResponse    `json:"prices"`
+		Height   int64                        `json:"height"`
 	}{
-		Height:   height,
 		Mappings: pairsResp.Mappings,
 		Prices:   pricesResp.Prices,
+		Height:   height,
 	}
 
 	err = m.broker.PublishRawSlinkyPrices(ctx, rawPrices)

--- a/modules/slinky_prices/module.go
+++ b/modules/slinky_prices/module.go
@@ -1,4 +1,4 @@
-package slinky_prices
+package slinkyprices
 
 import (
 	"context"
@@ -20,21 +20,23 @@ var (
 	_ types.BlockHandler = &Module{}
 )
 
-type Config struct {
-	StartSlinkyHeight int64
-}
+type (
+	broker interface {
+		PublishRawSlinkyPrices(ctx context.Context, data interface{}) error
+	}
 
-type Module struct {
-	log        *zerolog.Logger
-	rpcClient  *rpcClient.Client
-	grpcClient *grpcClient.Client
-	broker     broker
-	cfg        Config
-}
+	Config struct {
+		StartSlinkyHeight int64
+	}
 
-type broker interface {
-	PublishRawSlinkyPrices(ctx context.Context, data interface{}) error
-}
+	Module struct {
+		log        *zerolog.Logger
+		rpcClient  *rpcClient.Client
+		grpcClient *grpcClient.Client
+		broker     broker
+		cfg        Config
+	}
+)
 
 func New(cfg Config, b broker, rpcCli *rpcClient.Client, grpcCli *grpcClient.Client) *Module {
 	return &Module{

--- a/pkg/worker/config.go
+++ b/pkg/worker/config.go
@@ -5,8 +5,9 @@ import "time"
 type Config struct {
 	ProcessNewBlocksInterval   time.Duration `env:"PROCESS_NEW_BLOCKS_INTERVAL" envDefault:"1s"`
 	ProcessErrorBlocksInterval time.Duration `env:"PROCESS_ERROR_BLOCKS_INTERVAL" envDefault:"1m"`
-	ProcessNewBlocks           bool          `env:"SUBSCRIBE_NEW_BLOCKS"` // FIXME: or use ws enabled???
+	ProcessNewBlocks           bool          `env:"PROCESS_NEW_BLOCKS" envDefault:"false"`
 	ProcessErrorBlocks         bool          `env:"PROCESS_ERROR_BLOCKS" envDefault:"true"`
+	ReprocessBlocks            bool          `env:"REPROCESS_BLOCKS" envDefault:"false"`
 	MetricsEnabled             bool          `env:"METRICS_ENABLED" envDefault:"false"`
 	RecoveryMode               bool          `env:"RECOVERY_MODE" envDefault:"false"`
 	ProcessGenesis             bool          `env:"PROCESS_GENESIS" envDefault:"true"`

--- a/pkg/worker/config.go
+++ b/pkg/worker/config.go
@@ -3,6 +3,7 @@ package worker
 import "time"
 
 type Config struct {
+	ProcessNewBlocksInterval   time.Duration `env:"PROCESS_NEW_BLOCKS_INTERVAL" envDefault:"1s"`
 	ProcessErrorBlocksInterval time.Duration `env:"PROCESS_ERROR_BLOCKS_INTERVAL" envDefault:"1m"`
 	ProcessNewBlocks           bool          `env:"SUBSCRIBE_NEW_BLOCKS"` // FIXME: or use ws enabled???
 	ProcessErrorBlocks         bool          `env:"PROCESS_ERROR_BLOCKS" envDefault:"true"`

--- a/pkg/worker/process.go
+++ b/pkg/worker/process.go
@@ -59,7 +59,7 @@ func (w *Worker) processHeight(ctx context.Context, workerIndex int, height int6
 		}()
 	}
 
-	if err := w.checkOrCreateBlockInStorage(ctx, height); err != nil {
+	if err := w.checkOrCreateBlockInStorage(ctx, height); err != nil && !w.cfg.ReprocessBlocks {
 		switch {
 		case errors.Is(err, ErrBlockProcessed):
 			w.log.Debug().Int64(keyHeight, height).Msg("block already processed. skip height")

--- a/pkg/worker/process.go
+++ b/pkg/worker/process.go
@@ -95,9 +95,7 @@ func (w *Worker) processHeight(ctx context.Context, workerIndex int, height int6
 			return
 		}
 
-		if err = w.storage.SetProcessedStatus(ctx, height); err != nil {
-			w.log.Error().Err(err).Int64(keyHeight, height).Msg("can't set processed status in storage")
-		}
+		w.setProcessedStatus(ctx, height)
 
 		return
 	}
@@ -219,8 +217,16 @@ func (w *Worker) processHeight(ctx context.Context, workerIndex int, height int6
 		return
 	}
 
+	w.setProcessedStatus(ctx, height)
+}
+
+func (w *Worker) setProcessedStatus(ctx context.Context, height int64) {
 	if err := w.storage.SetProcessedStatus(ctx, height); err != nil {
 		w.log.Error().Err(err).Int64(keyHeight, height).Msg("can't set processed status in storage")
+	}
+
+	if err := w.storage.DeleteErrorTxs(ctx, height); err != nil {
+		w.log.Error().Err(err).Int64(keyHeight, height).Msg("can't delete error txs in storage")
 	}
 }
 

--- a/pkg/worker/queue.go
+++ b/pkg/worker/queue.go
@@ -47,6 +47,9 @@ func (w *Worker) enqueueNewBlocks(ctx context.Context, wg *sync.WaitGroup) {
 		return
 	}
 
+	// process the first new block height to prevent double processing attempts later
+	w.heightCh <- startHeight
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -59,7 +62,7 @@ func (w *Worker) enqueueNewBlocks(ctx context.Context, wg *sync.WaitGroup) {
 				continue
 			}
 
-			for height := startHeight; height <= stopHeight; height++ {
+			for height := startHeight + 1; height <= stopHeight; height++ {
 				w.log.Info().Int64("height", height).Msg("enqueueing new block")
 
 				// safe from closed channel

--- a/pkg/worker/queue.go
+++ b/pkg/worker/queue.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"sync"
 	"time"
-
-	cometbftcoreypes "github.com/cometbft/cometbft/rpc/core/types"
-	cometbfttypes "github.com/cometbft/cometbft/types"
 )
 
 func (w *Worker) enqueueHeight(ctx context.Context, wg *sync.WaitGroup, startHeight, stopHeight int64) {
 	defer wg.Done()
 
-	w.log.Debug().Msgf("try to parse: %d count of blocks", stopHeight-startHeight)
+	w.log.Debug().Msgf("try to parse: %d count of blocks", stopHeight-startHeight+1)
 
 	ctx, w.stopEnqueueHeight = context.WithCancel(ctx)
 	defer w.stopEnqueueHeight()
@@ -33,32 +30,48 @@ func (w *Worker) enqueueHeight(ctx context.Context, wg *sync.WaitGroup, startHei
 	}
 }
 
-func (w *Worker) enqueueNewBlocks(ctx context.Context, eventCh <-chan cometbftcoreypes.ResultEvent) {
-	ctx, w.stopWsListener = context.WithCancel(ctx)
-	defer w.stopWsListener()
-	w.log.Info().Msg("listening for new block events")
+func (w *Worker) enqueueNewBlocks(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	ticker := time.NewTicker(w.cfg.ProcessNewBlocksInterval)
+	defer ticker.Stop()
+
+	ctx, w.stopEnqueueNewBlocks = context.WithCancel(ctx)
+	defer w.stopEnqueueNewBlocks()
+
+	w.log.Info().Msg("parsing new blocks")
+
+	startHeight, err := w.rpcClient.GetLastBlockHeight(ctx)
+	if err != nil {
+		w.log.Error().Err(err).Str("func", "GetLastBlockHeight").Msg("can't enqueueNewBlocks")
+		return
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
-			w.log.Info().Msg("stop new block listener")
+			w.log.Info().Msg("stop new block parsing")
 			return
-		case e := <-eventCh:
-			newBlock, ok := e.Data.(cometbfttypes.EventDataNewBlock)
-			if !ok {
-				w.log.Warn().Msg("failed to cast ws event to EventDataNewBlock type")
+		case <-ticker.C:
+			stopHeight, err := w.rpcClient.GetLastBlockHeight(ctx)
+			if err != nil {
+				w.log.Warn().Err(err).Str("func", "GetLastBlockHeight").Msg("can't enqueueNewBlocks")
 				continue
 			}
 
-			height := newBlock.Block.Header.Height
-			w.log.Info().Int64("height", height).Msg("enqueueing new block")
+			for height := startHeight; height <= stopHeight; height++ {
+				w.log.Info().Int64("height", height).Msg("enqueueing new block")
 
-			select {
-			case <-ctx.Done():
-				w.log.Info().Msg("stop new block listener")
-				return
-			case w.heightCh <- height:
+				// safe from closed channel
+				select {
+				case <-ctx.Done():
+					w.log.Info().Msg("stop new block parsing")
+					return
+				case w.heightCh <- height:
+				}
 			}
+
+			startHeight = stopHeight
 		}
 	}
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"syscall"
 
@@ -31,7 +30,7 @@ type (
 		metrics *metrics
 
 		stopProcessing         func()
-		stopWsListener         func()
+		stopEnqueueNewBlocks   func()
 		stopEnqueueHeight      func()
 		stopEnqueueErrorBlocks func()
 
@@ -134,21 +133,18 @@ func (w *Worker) Start(_ context.Context) error {
 	}
 
 	// spawn workers
-	for i := 0; i < workersCount; i++ {
+	for i := range workersCount {
 		w.wg.Add(1)
 		go w.process(ctx, i, w.cfg.RecoveryMode) // run processing block function
 	}
 
-	// subscribe to process new blocks by websocket
-	if w.cfg.ProcessNewBlocks {
-		eventCh, err := w.rpcClient.SubscribeNewBlocks(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to subscribe to new blocks: %w", err)
-		}
-		go w.enqueueNewBlocks(ctx, eventCh)
-	}
-
 	wg := &sync.WaitGroup{}
+
+	// enqueue new blocks height
+	if w.cfg.ProcessNewBlocks {
+		wg.Add(1)
+		go w.enqueueNewBlocks(ctx, wg)
+	}
 
 	// enqueue error blocks height
 	if w.cfg.ProcessErrorBlocks {
@@ -181,7 +177,7 @@ func (w *Worker) Stop(_ context.Context) error {
 	w.stopEnqueueErrorBlocks()
 
 	if w.cfg.ProcessNewBlocks {
-		w.stopWsListener()
+		w.stopEnqueueNewBlocks()
 	}
 
 	close(w.heightCh)

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -102,8 +102,8 @@ func (w *Worker) Start(_ context.Context) error {
 	w.heightCh = make(chan int64, workersCount)
 
 	stopHeight := w.cfg.StopHeight
-	// check if stop height is empty, and we want to process height range from config
-	if stopHeight <= 0 && w.cfg.StartHeight >= 0 {
+	// check if stop height is empty or less than start height, and we want to process height range from config
+	if w.cfg.StartHeight >= 0 && (stopHeight <= 0 || stopHeight < w.cfg.StartHeight) {
 		var err error
 
 		stopHeight, err = w.rpcClient.GetLastBlockHeight(ctx)
@@ -174,7 +174,10 @@ func (w *Worker) Start(_ context.Context) error {
 
 func (w *Worker) Stop(_ context.Context) error {
 	w.stopEnqueueHeight()
-	w.stopEnqueueErrorBlocks()
+
+	if w.cfg.ProcessErrorBlocks {
+		w.stopEnqueueErrorBlocks()
+	}
 
 	if w.cfg.ProcessNewBlocks {
 		w.stopEnqueueNewBlocks()


### PR DESCRIPTION
Task: https://hadronlabs.atlassian.net/browse/NTRN-529

List of changes:
1. Replaced WebSocket-based retrieval of the latest block height with RPC requests that include a timeout.
2. Added the `PROCESS_NEW_BLOCKS_INTERVAL` environment variable to configure the timeout duration.
3. Refactored the worker’s `enqueueNewBlocks` method to use a ticker and track the last processed block height.
4. Added additional check `stopHeight` is greater than or equal to `startHeight`.
5. Added removal of txs from `error_txs` after successful block reprocessing.